### PR TITLE
Recognize correct test method(not only with @Test)

### DIFF
--- a/src/main/java/org/spideruci/asserttracker/AssertTrackingClassVisitor.java
+++ b/src/main/java/org/spideruci/asserttracker/AssertTrackingClassVisitor.java
@@ -24,12 +24,15 @@ public class AssertTrackingClassVisitor extends ClassVisitor {
 
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-        if (name.endsWith("Test")) {
-            this.isTestClass = true;
-            this.testClassName = name.replace("/",".");
-        }else{
-            this.testClassName = "NoneTestClass";
-        }
+//        if (name.endsWith("Test")) {
+//            this.isTestClass = true;
+//            this.testClassName = name.replace("/",".");
+//        }else{
+//            this.testClassName = "NoneTestClass";
+//        }
+        //sometimes they are not names for test classes, but it doesn't matter. Since we only print out assertion info
+        //it indicates that it's a test class name
+        this.testClassName = name.replace("/",".");
         super.visit(version, access, name, signature, superName, interfaces);
     }
 

--- a/src/main/java/org/spideruci/asserttracker/AssertVisitor.java
+++ b/src/main/java/org/spideruci/asserttracker/AssertVisitor.java
@@ -36,10 +36,14 @@ public class AssertVisitor extends MethodVisitor {
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
 
         // 1. if annotation present, then set the flag to true
-        //@org.junit.jupiter.api.Test()
-        if ("Lorg/junit/jupiter/api/Test;".equals(desc)){
+        //@org.junit.jupiter.api.Test() is not enough.
+        //may be @MultilocaleTest?
+        if(desc.endsWith("Test")){
             isTestAnnotationPresent = true;
         }
+//        if ("Lorg/junit/jupiter/api/Test;".equals(desc)){
+//            isTestAnnotationPresent = true;
+//        }
         return super.visitAnnotation(desc, visible);
     }
 


### PR DESCRIPTION
There are different annotations that indicate a method within a test class is a test method.
For example, @Test, @MultilocaleTest. Therefore, any annotations ends with "Test" would be recognized as test methods